### PR TITLE
Published "archive" page, updated the "about us" section in "home"

### DIFF
--- a/src/archive/data.en.yaml
+++ b/src/archive/data.en.yaml
@@ -5,12 +5,13 @@ aliases:
 
 hero:
   title: Archive
-  desc: This page is here to show you our roots – our former teams, photos of our work process, captures taken during competitions, and more.
+  desc: This page is here to show you our history – our former teams, photos of our work process, captures taken during competitions, and more.
 
 teams:
   title: Former teams
   jupp: 
-    title: Üks Jupp
+    title: ÜksJupp
+    url: /archive/jupp
     text: A group which was formed in the early days of VHK STEM. Competed in England twice with the last time being in the fall of 2024.
 
 seeMore: Read more

--- a/src/archive/data.et.yaml
+++ b/src/archive/data.et.yaml
@@ -8,6 +8,7 @@ teams:
   title: Endised meeskonnad
   jupp: 
     title: ÜksJupp
+    url: /arhiiv/jupp
     text: Meeskond mis loodi juba MATIKu algusaegadel. On käinud kahel korral Inglismaal võistlemas, viimane kord 2024. aasta sügisel.
 
 seeMore: Loe edasi

--- a/src/archive/index.pug
+++ b/src/archive/index.pug
@@ -16,7 +16,7 @@ block content
                     .team-item-content
                         h2= self.teams.jupp.title
                         p= self.teams.jupp.text
-                        a.link-button(href=self.nav.teams[0].url)= self.seeMore
+                        a.link-button(href=self.teams.jupp.url)= self.seeMore
         
         .gallery.container.container-m
             h1= self.gallery.title

--- a/src/archive/style.styl
+++ b/src/archive/style.styl
@@ -6,12 +6,12 @@ h1
 
 // Hero section (change background image here)
 .hero
-    padding: 9em 0 5em 0;
+    padding: 15em 0 5em 0;
     //margin-bottom: 2rem;
     background-image: linear-gradient(
       rgba(0, 0, 0, 0.5),
       rgba(0, 0, 0, 0.55)
-    ),url("/assets/VHK_matik_logo.webp");
+    ),url("/assets/photo-collage.png");
     background-position: center
     background-size: cover;
 

--- a/src/global.en.yaml
+++ b/src/global.en.yaml
@@ -7,8 +7,6 @@ nav:
   #   title: Contact
   #   url: /contact
   teams:
-    - title: 1Jupp
-      url: /teams/jupp
     - title: BeeGreen
       url: /teams/beegreen
     - title: Vurts
@@ -23,9 +21,9 @@ nav:
   sponsor:
     title: Sponsor
     url: /sponsor
-#   archive:
-#     title: Archive
-#     url: /archive
+  archive:
+    title: Archive
+    url: /archive
 
 footer:
   sitemap: "Sitemap"

--- a/src/global.et.yaml
+++ b/src/global.et.yaml
@@ -7,8 +7,6 @@ nav:
   #   title: Kontakt
   #   url: /et/kontakt
   teams:
-    - title: 1Jupp
-      url: /et/tiimid/jupp
     - title: BeeGreen
       url: /et/tiimid/beegreen
     - title: Vurts
@@ -23,9 +21,9 @@ nav:
   sponsor:
     title: Sponsor
     url: /et/sponsor
-#   archive:
-#     title: Arhiiv
-#     url: /et/arhiiv
+  archive:
+    title: Arhiiv
+    url: /et/arhiiv
 
 footer:
   sitemap: "Lingid"

--- a/src/home/data.en.yaml
+++ b/src/home/data.en.yaml
@@ -9,34 +9,23 @@ hero:
 
 sponsorsTitle: Sponsors
 
-aboutUsAsMarkdown: "
-  # About Us
+aboutUs: 
+  title: About Us
+  text: VHK STEM course is an extracurricular activity for the high school students in the Old Town Educational College of Tallinn which is available to students studying in the engineering field. The program is divided into 4 groups where each team works on one Greenpower car. In a team, each member has their own responsibilities – from working on the car's design and mechanics to marketing and branding.
 
-  VHK STEM is a Greenpower STEM class for high school students in the engineering class which operates as an extracurricular activity in the Old Town Educational College secondary education's engineering class' curriculum.
+  title2: What is STEM?
+  text2: STEM is an acronym for a study method which combines Science, Technology, Engineering, and Mathematics. The objective of the program is to give students the ability to exercise theory learnt in a classroom and apply it in real life situations. A specialty of VHK STEM is that the students are put into a group environment which gives them the means to gain experience on how to coordinate workflow and run an enterprise of their own.
 
-
-
-  VHK STEM is divided into 4 teams where each team works on one Greenpower car. In a team, each member has their own responsibilities: from working on the car's design to marketing and branding. VHK STEM program gets students from theoretical classes to work on practical projects while cultivating a harmonious team.
-
-
-
-  We have already competed twice in the UK and plan to go again next spring 2024.
-
-
-
-  ## What does STEM mean?
-
-
-
-  STEM stands for Science, Technology, Engineering, and Mathematics. The goal of the program is to get students interested in STEM fields and to give them practical experience in engineering. In addition in VHK Matik, students get the experience of working in a team, doing marketing, and solving practical problems.
-
-  "
+  title3: Achievements
+  text3: "So far we have competed in three different Greenpower competitions:"
+  
+  list: 
+    - F24+ Round 6 - Lotus Hethel 2023
+    - F24 International Final 2023
+    - F24+ Round 13 - International Final 2024
 
 teamsTitle: Teams
 learnMore: Learn more
-
-juppTitle: 1 Jupp
-jupp: Currently the oldest team who competed 32nd out of 37th in the F24+ Greenpower Finals with the car Weiko Kalew. The team is still continuing to improve the car to reach even newer heights.
 
 cotton: A new team established in the fall of 2023.
 

--- a/src/home/data.et.yaml
+++ b/src/home/data.et.yaml
@@ -6,33 +6,23 @@ hero:
 
 sponsorsTitle: Sponsorid
 
-aboutUsAsMarkdown: "
-  # Meist
+aboutUs: 
+  title: Meist
+  text: VHK MATIKu kursus on õppekava väline tegevus mõeldud Vanalinna Hariduskolleegiumi inseneeriaharu õpilastele. Õpilased on jaotatud nelja gruppi ning iga meeskond tegeleb oma Greenpoweri vormeli ehitamisega. Igal tiimiliikmel on meeskonnas oma valdkond mille eest ta vastutama peab – auto kehadisainist ja mehaanikast kuni turunduse ja brändinguni.
 
-  Oleme Vanalinna Hariduskolleegiumi inseneeria klassi õpilased ja ehitame Greenpoweri elektriautosid.
+  title2: Mis on MATIK?
+  text2: MATIK on viiel valdkonnal tuginev õpe mis ühendab matemaatika, tehnoloogia, teaduse, inseneeria ja kunstid. Programmi eesmärk on anda õpilastele võimalus rakendada klassiruumis õpitud teooriat päriselu olukordades. Üks VHK MATIKu eripäradest on see, et õpilased peavad töötama ühtsete meeskondadena, mis annab neile võimaluse õppida kuidas koordineerida koostööd ja juhtida omaenda ettevõtet.
 
-
-
-  Neljaks tiimiks jaotununa, kus igal tiimil on oma auto, saame kokku regulaarselt kord nädalas, aga suur osa tööst toimub ka väljaspool tundi.
-
-
-
-  Oleme varem käinud juba kaks korda UK-s võistlemas, ja kavatseme minna ka tuleval kevadel.
-
-
-
-  ## Mis asi on MATIK?
-
-
-
-  MATIK (e. STEM) on akronüüm, mis tähendab matemaatika, tehnika, teadus, inseneeria ja kunst. See tähistab õppetööd või tundi, kus projekti tegemise käigus on vaja kasutada neid teadmisi. Lisaks VHK Matik lisakursusel on vaja ka tugevat meeskonna töö, turunduse ning probleemide lahendamise oskuseid. Kursuse eesmärk on pakkuda inseneeria õpilastele praktilist kogemust.
-  "
+  title3: Saavutused
+  text3: "Senini oleme me võistelnud kolmel korral Greenpoweri võistlustel:"
+  
+  list: 
+    - • F24+ Round 6 - Lotus Hethel 2023
+    - • F24 International Final 2023
+    - • F24+ Round 13 - International Final 2024
 
 teamsTitle: Meeskonnad
 learnMore: Loe rohkem
-
-juppTitle: Üks Jupp
-jupp: Hetkel vanim tiim Matik-us, kes võistles F24+ Greenpoweri finaalis autoga Weiko Kalew ja sai 32. koha 37-st. Tiim jätkab auto täiustamist, et saavutada veelgi kõrgemaid tulemusi.
 
 cotton: 2023 sügisel asutatud uus tiim.
 

--- a/src/home/index.pug
+++ b/src/home/index.pug
@@ -28,29 +28,35 @@ block content
                     img(src="/assets/espak_logo.png" alt="Espak logo")
                 
 
-        .about-us.container.container-m!= self.md(self.aboutUsAsMarkdown)
+        .about-us.container.container-m
+            h1= self.aboutUs.title
+            p= self.aboutUs.text
+
+            h2= self.aboutUs.title2
+            p= self.aboutUs.text2
+
+            h2= self.aboutUs.title3
+            p= self.aboutUs.text3
+
+            ul
+                each achievement in self.aboutUs.list
+                    li= achievement
 
         .container.container-m
             h1= self.teamsTitle
             .teams
-                .jupp.team-item
-                    img(src="/assets/onejupp/P2400708.webp" alt="1 Jupp team photo")
-                    .team-item-content
-                        h2= self.juppTitle
-                        p= self.jupp
-                        a.link-button(href=self.nav.teams[0].url)= self.learnMore
                 .beegreen.team-item
                     img(src="/assets/beegreen/hero.webp" alt="Beegreen team logo")
                     .team-item-content
                         h2 Beegreen
                         p= self.beegreen
-                        a.link-button(href=self.nav.teams[1].url)= self.learnMore
+                        a.link-button(href=self.nav.teams[0].url)= self.learnMore
                 .cotton.team-item
                     img(src="/assets/pinkpython/image_123650291.webp" alt="Pink Python team's car on test track")
                     .team-item-content
                         h2 Cotton Candy Cruiser
                         p= self.cotton 
-                        a.link-button(href=self.nav.teams[4].url)= self.learnMore
+                        a.link-button(href=self.nav.teams[3].url)= self.learnMore
 
         .container.container-m
             h1= self.mediaTitle

--- a/src/home/style.styl
+++ b/src/home/style.styl
@@ -45,6 +45,9 @@ h3
     width: 10em
     border-radius: 0px;
 
+.about-us
+    padding: 0.75em 3rem 3em 3rem
+
 .teams
     display: flex
     flex-direction: column

--- a/src/teams/jupp/data.en.yaml
+++ b/src/teams/jupp/data.en.yaml
@@ -1,7 +1,7 @@
-path: "/teams/jupp"
+path: "/archive/jupp"
 
 aliases:
-  - "/en/teams/jupp"
+  - "/en/archive/jupp"
 
 hero:
   title: 1Jupp RC
@@ -25,10 +25,6 @@ members:
     role: "Website Development"
     image: "/assets/onejupp/IMG_3528.webp"
     imageChange: "/assets/onejupp/IMG_3532.webp"
-  - name: "Tristjan Lutter"
-    role: "Electronics"
-    image: "/assets/onejupp/IMG_3506.webp"
-    imageChange: "/assets/onejupp/IMG_3510.webp"
   - name: "Georg Pärtel Põldmäe"
     role: "Leader, Aerodynamics & Bodywork"
     image: "/assets/onejupp/IMG_3523.webp"
@@ -37,3 +33,22 @@ members:
     role: "Bodywork"
     image: "/assets/onejupp/IMG_3515.webp"
     imageChange: "/assets/onejupp/IMG_3521.webp"
+  - name: "Tristjan Lutter"
+    role: "Electronics"
+    image: "/assets/onejupp/IMG_3506.webp"
+    imageChange: "/assets/onejupp/IMG_3510.webp"
+  - name: "Joonatan Jürisson"
+    role: "Telemetry"
+    image: "/assets/onejupp/IMG_3501.webp"
+    imageChange: "/assets/onejupp/IMG_3504.webp"
+  - name: "Marti Zupping"
+    role: "Telemetry"
+    image: "/assets/onejupp/IMG_3496.webp"
+    imageChange: "/assets/onejupp/IMG_3500.webp"
+  - name: "Henri Turban"
+    role: "Aerodynamics"
+    image: "/assets/onejupp/IMG_3511.webp"
+    imageChange: "/assets/onejupp/IMG_3514.webp"
+
+achievements:
+  text:

--- a/src/teams/jupp/data.et.yaml
+++ b/src/teams/jupp/data.et.yaml
@@ -1,4 +1,4 @@
-path: "/tiimid/jupp"
+path: "/arhiiv/jupp"
 
 hero:
   title: ÜksJupp rallitiim
@@ -22,10 +22,6 @@ members:
     role: "Veebisaidi arendaja"
     image: "/assets/onejupp/IMG_3528.webp"
     imageChange: "/assets/onejupp/IMG_3532.webp"
-  - name: "Tristjan Lutter"
-    role: "Elektroonika"
-    image: "/assets/onejupp/IMG_3506.webp"
-    imageChange: "/assets/onejupp/IMG_3510.webp"
   - name: "Georg Pärtel Põldmäe"
     role: "Juht, aerodünaamika ja keretööd"
     image: "/assets/onejupp/IMG_3523.webp"
@@ -34,3 +30,22 @@ members:
     role: "Keretööd"
     image: "/assets/onejupp/IMG_3515.webp"
     imageChange: "/assets/onejupp/IMG_3521.webp"
+  - name: "Tristjan Lutter"
+    role: "Elektroonika"
+    image: "/assets/onejupp/IMG_3506.webp"
+    imageChange: "/assets/onejupp/IMG_3510.webp"
+  - name: "Joonatan Jürisson"
+    role: "Telemeetria"
+    image: "/assets/onejupp/IMG_3501.webp"
+    imageChange: "/assets/onejupp/IMG_3504.webp"
+  - name: "Marti Zupping"
+    role: "Telemeetria"
+    image: "/assets/onejupp/IMG_3496.webp"
+    imageChange: "/assets/onejupp/IMG_3500.webp"
+  - name: "Henri Turban"
+    role: "Aerodünaamika"
+    image: "/assets/onejupp/IMG_3511.webp"
+    imageChange: "/assets/onejupp/IMG_3514.webp"
+
+achievementsList:
+  achievements:

--- a/src/teams/vurts/data.en.yaml
+++ b/src/teams/vurts/data.en.yaml
@@ -10,11 +10,11 @@ hero:
 team:
   text: "## About us
 
-    Longer description
+    We're a new team consisting of 10th grade students. Established in the fall of 2024.
 
 
 
-    [Facebook](hyperlink)"
+    [Facebook](https://www.facebook.com/profile.php?id=61566576933015)"
 
 memberTitle: "Team Members"
 

--- a/src/teams/vurts/data.et.yaml
+++ b/src/teams/vurts/data.et.yaml
@@ -8,7 +8,7 @@ hero:
 team:
   text: "## Meist
 
-    Pikem kirjeldus
+    Me oleme uus meeskond, mis koosneb 10. klassi õpilastest. Asutatud 2024. aasta sügisel.
 
 
 


### PR DESCRIPTION
Removed 1jupp from homepage and put their site to the archive (currently the site is still stored in the "teams" source folder). Their team description will be updated soon. Updated the text under "about us" on the homepage and added a list of races MATIK's teams have been to. A minor issue with the bullet points being placed on the margins remains. Added description for team "vurts"